### PR TITLE
Use --rm option for docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ ISOLATED_DOCKER_NETWORK_NAME=exec_env_jail_network
 
 cat local_test/test_stdin/stdin.csv | \
 docker run --init \
+        --rm \
         --attach "stdin" \
         --attach "stdout" \
         --attach "stderr" \
@@ -319,6 +320,7 @@ ISOLATED_DOCKER_NETWORK_NAME=exec_env_jail_network
 
 cat local_test/test_stdin/stdin.csv | \
 docker run --init \
+        --rm \
         --attach "stdin" \
         --attach "stdout" \
         --attach "stderr" \


### PR DESCRIPTION
Since these test runs are transient containers and logs are being handled externally with file redirection, there is no reason for the containers to persist after the process has completed.  Adding `--rm` avoids many stopped containers piling up from repeated test runs.